### PR TITLE
docs(skills): add mandatory progress tracking to 5-whys skill

### DIFF
--- a/.claude/skills/5-whys/SKILL.md
+++ b/.claude/skills/5-whys/SKILL.md
@@ -29,6 +29,12 @@ You MUST search the codebase and gather evidence between each "why" question. If
 
 ---
 
+## ✅ MANDATORY: Progress Tracking
+
+Use a todo list to track each "why" round. Mark complete before proceeding to the next.
+
+---
+
 ## Investigation Techniques
 
 Evidence gathering is the core of each "why" iteration. Use these approaches flexibly — they're starting points, not checklists.


### PR DESCRIPTION
## Summary

- Added `✅ MANDATORY: Progress Tracking` section to the 5-whys debugging skill
- Requires use of todo list to track each "why" round systematically

## Changes

```markdown
## ✅ MANDATORY: Progress Tracking

Use a todo list to track each "why" round. Mark complete before proceeding to the next.
```

Syncs with changes made in `openbox-deal-finder` repo.