### PR TITLE
Add Linux notes section to gitingest skill

### DIFF
--- a/.claude/skills/gitinjest/SKILL.md
+++ b/.claude/skills/gitinjest/SKILL.md
@@ -17,6 +17,11 @@ Key lesson: Always search broadly first (-i "*.ts" for TypeScript, -i "*.py" for
 pipx install gitingest
 ```
 
+### Linux Notes
+- If `pip install --user` fails with PEP 668 error, use `pipx install gitingest` instead.
+- If `gitingest: command not found`, ensure `~/.local/bin` is on PATH. Run `pipx ensurepath` then restart your shell.
+- Verify: `gitingest --help` or `pipx list | grep gitingest`
+
 ## Default Usage (Streaming to stdout)
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a `### Linux Notes` section to `.claude/skills/gitinjest/SKILL.md` immediately after the Installation code block
- Documents common PEP 668 error workaround and PATH troubleshooting for Linux users

## Changes
- Added 3 troubleshooting bullets for Linux-specific installation issues:
  - PEP 668 error solution using pipx
  - PATH configuration with `pipx ensurepath`
  - Verification commands

## No other changes
All other content (frontmatter, headings, existing documentation) remains unchanged.