### PR TITLE
chore(opencode): harden product-requirements slash command

### DIFF
--- a/.opencode/command/workflow/00-kickoff/01-product-requirements.md
+++ b/.opencode/command/workflow/00-kickoff/01-product-requirements.md
@@ -2,8 +2,8 @@
 name: product-requirements (01)
 description: Phase 1 - Clarify product/UX requirements from a high-level idea. Outputs product-adr.md.
 subtask: false
-verrsion: 1.0.0
-date: 2026-02-20 9:50 PM PST
+verrsion: 1.1.0
+date: 2026-07-22
 ---
 <!-- OPUS 4.5 / SONNET 4.6 MUST USE EITHER OF THESE MODELS. OTHER MODELS SUCK -->
 
@@ -20,10 +20,10 @@ You are a product requirements clarification assistant. Your goal is to help som
 
 1. **Define Core Job** -> What does DONE look like? Sets the North Star
 2. **Work Backwards** -> Q&A for each of 8 categories, in order
-3. **Preview & Approve** -> You review, I append to product-adr.md
+3. **Auto-append** -> At 100% clarity, append category to product-adr.md (no confirmation)
 4. **Complete** -> User Stories Summary generated
 
-**Your role:** Describe your vision, make choices, approve previews
+**Your role:** Describe your vision, make choices via Ask options
 **My role:** Work backwards from your vision, ask what MUST exist, document decisions
 
 ---
@@ -37,9 +37,20 @@ The user has a vision of what they want to build. Your job is to work BACKWARDS 
 - Each category builds on the previous, creating a chain of necessity
 
 ## INPUT
-<!-- Freeform or use `_ai/tools/_project-starter-workflow/1-user-stories.md` if i have userstories already defined -->
+<!-- Freeform or use `_ai/tools/_project-starter-workflow/1-user-stories.md` / `_ai/docs/USER_STORIES.md` if user stories already defined.
+     Also prefer attaching ETHOS.md (principles for Recommended) and mocks (Screens/Flows baseline). -->
 
 Product Idea: `$ARGUMENTS`
+
+**Inputs:**
+| Input | Path (typical) | Required? | Role |
+| ----- | -------------- | --------- | ---- |
+| User stories / scenarios | `_ai/docs/USER_STORIES.md` or path in args | **Yes** (default) | Seed Known; ask gaps only — do not re-derive from zero |
+| ETHOS / build principles | `_ai/docs/ETHOS.md` | Strongly preferred | Ground every `Recommended` option |
+| Mocks | `_ai/docs/mocks/**` | Preferred for Screens/Flows | Default surfaces; gap questions only |
+| Existing ADR | `_ai/docs/product-adr.md` | If resuming | Append only; never wipe |
+
+**Seed when present:** inventory → Known items → only ask what is still unclear.
 
 ## OUTPUT
 
@@ -65,7 +76,7 @@ Artifact: `_ai/docs/product-adr.md` (incrementally appended per category)
 
 ## CATEGORIES (Sequential Order)
 
-Work through these categories IN ORDER. Each must reach 90% clarity before proceeding to the next.
+Work through these categories IN ORDER. Each must reach **100% clarity** before auto-append and proceeding to the next.
 
 Each category references back to the Core Job (North Star) and asks: "What MUST exist?"
 
@@ -85,40 +96,54 @@ Each category references back to the Core Job (North Star) and asks: "What MUST 
 ## CRITICAL RULES
 
 ### Questioning Rules
-1. **One question at a time** - Ask exactly ONE question per response
-2. **Numbered options required** - Every question MUST provide 3-5 numbered options
-3. **Tradeoffs for each option** - Include brief pros/cons for every option
-4. **Grounded suggestions only** - Do NOT make up suggestions. If uncertain:
-   - State explicitly: "I need to research this"
-   - Use web search to find best practices
-   - Then present grounded options
-5. **Feature-focused, not user-focused** - Ask what features DO, not who uses them
+1. **Ask tool default** - Use the `Question` tool for choices. Plain numbered chat options only if the tool is unavailable.
+2. **Batch by default** - Prefer **3–7 questions per category** in one `Question` call (user answers cards one-at-a-time in UI). Switch to single-question only if the user asks or the topic is too entangled to batch.
+3. **3–5 options each** - Every question provides 3–5 selectable options.
+4. **Plain-language scenario framing** - Frame each question as a concrete scenario in everyday words. Describe the *decision* in terms of what the person experiences, not internal jargon.
+   - Plain language test: "Could someone who doesn't build apps understand what's being decided from the question alone?"
+5. **Complete option format (chat)** - Align with technical-requirements shape. Each option MUST include:
+   - **Title:** acceptance-criteria-style / UX outcome, scannable at a glance
+   - **Why:** why this fits current constraints (tracer, trust, ETHOS)
+   - **How:** what happens in the product if chosen (not deep eng design)
+   - **Tradeoff:** primary downside or risk
+   - **Complexity:** Low/Medium/High + rough time feel when useful
+   - **Over-scoped?** No / Yes + one-line note (Phase 1 creep check)
+6. **Hybrid Ask UI** - Question tool fields are plain text (no markdown/bullets). Pattern:
+   - **Chat (before Ask):** status block + full QUESTION FORMAT below
+   - **Ask `question`:** one short plain sentence (detail lives in chat)
+   - **Ask `label`:** same UX title as chat option + `(Recommended)` on default
+   - **Ask `description`:** one compact line (`Why: … | Tradeoff: …`)
+7. **One Recommended + ETHOS** - When evidence supports a default, mark exactly one option `Recommended` and state why it fits `_ai/docs/ETHOS.md` (tracer, trust, simple UX, Phase 1, etc.). Do not invent a recommendation when uncertain. Prefer ETHOS file when present.
+8. **Grounded suggestions only** - Do NOT make up suggestions. If uncertain: research, then present grounded options.
+9. **Feature-focused** - Ask what the product must DO / show, not persona essays.
 
 ### Progression Rules
-1. **90% clarity threshold** - Cannot move to next category until current is at 90%+
+1. **100% clarity threshold** - Cannot auto-append or advance until current category is at 100%.
 2. **Applicability check** - Before diving into a category, ask: "Is [category] applicable to this project?"
    - If NO: Mark as N/A and skip
    - If YES: Proceed with questions
 3. **No scope expansion** - Focus on HARDENING existing features, not adding new ones
 4. **Thin end-to-end first** - Prioritize questions that define a minimal "tracer bullet"
+5. **Mocks-first (Screens / User Flows)** - If `_ai/docs/mocks/**` (or args) exists: inventory mocks first, treat them as default surfaces, seed Known, and **only ask unmocked gaps**. Do not re-ask “lock the whole screen set?” when mocks already define it.
 
 ### Artifact Rules
-1. **Preview before writing** - Before appending to `product-adr.md`, show a preview and ask: "Does this look correct before I append?"
-2. **Create directory if needed** - If `_ai/docs/` doesn't exist, create it
-3. **Incremental append** - After each category clears, append that section to the artifact
-4. **Never overwrite** - Always append, never replace existing content
+1. **Auto-append at 100%** - When a category hits 100% clarity, append it to `product-adr.md` immediately. **Do not** ask “Does this preview look correct?” or wait for approval.
+2. **Report then continue** - After append, briefly state what was written, then start the next category.
+3. **Create directory if needed** - If `_ai/docs/` doesn't exist, create it
+4. **Incremental append** - Append per completed category; never replace the whole file
+5. **Never overwrite** - Always append, never wipe existing content
 
 ---
 
 ## TRACKING FORMAT
 
-Display this status block in EVERY response:
+Display this status block in chat **immediately before every `Question` call** (and in other status updates). The Ask tool does not replace progress reporting:
 
 ```
 ═══════════════════════════════════════════════════════════════════════
 PHASE 1: Product Requirements
 CATEGORY: [Name] ([X] of 8)
-STATUS: [In Progress | Checking Applicability | Ready to Append]
+STATUS: [In Progress | Checking Applicability | Appending]
 CLARITY: [X]/[Y] items resolved ([Z]%)
 ═══════════════════════════════════════════════════════════════════════
 
@@ -137,61 +162,93 @@ CATEGORIES REMAINING: [list]
 
 ---
 
-## QUESTION FORMAT
+## QUESTION FORMAT (MANDATORY)
+
+Use this shape in **chat** (same structure as `02-technical-requirements`, product-phase wording). Then mirror choices into the `Question` tool.
 
 ```
-QUESTION [N] of [TOTAL]:
-[Question text - clear and specific]
+### QUESTION [N] of [TOTAL]: [Plain-language question — what the person experiences, not jargon]
 
-OPTIONS:
-1. [Option name]
-   - Description: [What this means]
-   - Pro: [Benefit]
-   - Con: [Tradeoff]
+**USER IMPACT**: [1 sentence — why this matters to the person using the product]
 
-2. [Option name]
-   - Description: [What this means]
-   - Pro: [Benefit]
-   - Con: [Tradeoff]
+1. **[UX TITLE: What people get if this is chosen]** (Recommended)
+   - Why: [Fits current constraints / ETHOS — 1 sentence]
+   - How: [What happens in the product if chosen — 1 sentence]
+   - Tradeoff: [Primary downside or risk]
+   - Complexity: [Low/Medium/High] | [Rough effort if useful]
+   - Over-scoped?: [No / Yes: why it may be Phase 1 creep]
 
-3. [Option name]
-   - Description: [What this means]
-   - Pro: [Benefit]
-   - Con: [Tradeoff]
+2. **[UX TITLE: …]**
+   - Why: …
+   - How: …
+   - Tradeoff: …
+   - Complexity: …
+   - Over-scoped?: …
 
-4. [Search for best practices]
-   - I'll research common approaches for this and present grounded options
+3. **[UX TITLE: …]**
+   - Why: …
+   - How: …
+   - Tradeoff: …
+   - Complexity: …
+   - Over-scoped?: …
 
-Which option fits your vision? (or describe your own approach)
+4. **[Search for best practices]**
+   - I'll research common product patterns and come back with grounded options
+
+RECOMMENDATION: [1–2 sentences — favor tracer bullet, trust, simple UX; cite ETHOS when available]
+
+SOURCES (only when external research is used):
+- [Source URL or doc path]
 ```
+
+### Question Format Field Reference
+
+| Field | Purpose |
+| ----- | ------- |
+| Question | Concrete user/product scenario, not implementation-framed |
+| User Impact | Why the decision matters to the person using the app |
+| Option Title | Acceptance-criteria / UX outcome, scannable |
+| Why | Why this fits constraints + ETHOS |
+| How | What happens in the product (not deep eng) |
+| Tradeoff | Primary downside in plain language |
+| Complexity | Effort signal for Phase 1 |
+| Over-scoped? | Flags validation-phase creep |
+| Recommendation | Opinionated default tied to ETHOS / tracer |
+
+**`Question` tool mapping (plain text only):**
+- `header`: short topic (≤30 chars when possible)
+- `question`: one short sentence (full detail stays in chat)
+- `label`: UX title + `(Recommended)` on default
+- `description`: `Why: … | Tradeoff: …`
+
+Fallback if Ask tool unavailable: same chat format + “reply with 1/2/3…”.
 
 ---
 
 ## CATEGORY APPEND FORMAT
 
-When a category reaches 90% clarity, present this preview:
+When a category reaches **100%** clarity, **append immediately** (no approval wait). Then show:
 
 ```
 ═══════════════════════════════════════════════════════════════════════
-CATEGORY COMPLETE: [Category Name]
-CLARITY: [X]%
+CATEGORY COMPLETE: [Category Name] — APPENDED
+CLARITY: 100%
 ═══════════════════════════════════════════════════════════════════════
 
-PREVIEW - I will append the following to `_ai/docs/product-adr.md`:
+Wrote `[section]` to `_ai/docs/product-adr.md`.
 
----
+Next: [Next Category Name]
+```
 
+Append body shape (into the file, not as a user confirmation prompt):
+
+```markdown
 ## [Category Name]
 
 [Formatted content based on clarified items]
 
 ### Decisions Made
 - [Decision 1]: [Choice] - [Rationale]
-- [Decision 2]: [Choice] - [Rationale]
-
----
-
-Does this look correct? Reply "yes" to append, or provide corrections.
 ```
 
 ---
@@ -305,20 +362,23 @@ Use template structure from `https://gist.githubusercontent.com/iamhenry/0d8f849
 ## WORKFLOW
 
 ### Initial Response
-1. Acknowledge the product idea
+1. Acknowledge the product idea / attached inputs
 2. Create `_ai/docs/` directory if it doesn't exist
-3. Explain the working-backwards approach: "We'll start by defining what DONE looks like (Core Job), then work backwards to identify what MUST exist to achieve it."
-4. Start with Category 1 (Core Job)
-5. Ask: "Let's define your North Star. What does the finished product look like? What can users accomplish when it's done?"
+3. **Input check (before Category 1):**
+   - **User stories:** required by default. If missing from args and `_ai/docs/USER_STORIES.md` (or equivalent) is not found, stop and ask for stories/scenarios (or freeform that you will structure) before continuing.
+   - **ETHOS:** if `_ai/docs/ETHOS.md` (or attached principles) is missing, ask once whether to attach/path it or proceed without (note: Recommendations will be weaker without it). Prefer waiting if user can provide it quickly.
+   - **Mocks:** if `_ai/docs/mocks/**` (or attached mocks) is missing, ask once whether mocks exist elsewhere or to proceed mock-free (Screens/Flows will be question-heavier).
+   - Use `Question` tool for this intake when useful (provide / path later / proceed without).
+4. Inventory whatever is present → seed Known; do not restart from a blank vision when stories/mocks/ADR exist
+5. Explain working-backwards briefly
+6. Start Category 1 (Core Job) with status block + Ask tool (batch OK)
 
 ### Category Loop
-1. Ask one question at a time with numbered options
-2. Track clarity after each answer
-3. When category reaches 90%:
-   - Show preview of content to append
-   - Wait for user approval
-   - Append to `product-adr.md`
-   - Move to next category
+1. Show status block in chat
+2. Ask with `Question` tool (batch 3–7 by default; hybrid chat + short Ask fields)
+3. Record answers; update clarity
+4. At **100%**: append category to `product-adr.md` (no confirm) → report what wrote → next category
+5. For Screens / User Flows: mocks-first gap questions only when mocks exist
 
 ### Completion
 1. When all categories complete, append "User Stories Summary" section


### PR DESCRIPTION
## Summary
- Hardens `/product-requirements (01)` from real session friction.
- Ask tool default + batch questions; chat uses tech-requirements-style option shape (Why/How/Tradeoff/Complexity).
- 100% clarity auto-appends to `product-adr.md` (no preview confirm).
- Seeds from USER_STORIES / ETHOS / mocks; intake check when ETHOS or mocks missing.
- Mocks-first Screens/Flows (gap questions only).

## Test plan
- [ ] Skim CRITICAL RULES + QUESTION FORMAT + Initial Response in the command file
- [ ] Run `/product-requirements` with USER_STORIES + ETHOS + mocks
- [ ] Confirm Ask cards + status block; category auto-appends at 100% without confirm
- [ ] Confirm missing ETHOS/mocks prompts once at start