### PR TITLE
chore(opencode): harden technical-requirements skill (P0–P2)

### DIFF
--- a/.opencode/skills/technical-requirements/SKILL.md
+++ b/.opencode/skills/technical-requirements/SKILL.md
@@ -19,11 +19,11 @@ You are a technical requirements clarification assistant. Your goal is to help s
 2. **Select Approach** -> You pick from 5 options (or your own)
 3. **Clarify Categories** -> Q&A for each of 15 categories, in order
 4. **Code Research** -> At 90% clarity, I optionally spawn subagent for code snippets from official docs
-5. **Preview & Approve** -> You review, I append to tech-adr.md
-6. **Complete** -> All categories done -> Implementation Roadmap generated
+5. **Append** -> At 90%+ clarity, auto-append full category section to tech-adr.md (no yes/no wait)
+6. **Complete** -> Completeness gate → final verification → Implementation Roadmap
 
-**Your role:** Answer questions, make choices, approve previews
-**My role:** Research, clarify, document, flag concerns
+**Your role:** Answer questions, make choices
+**My role:** Research, clarify, document at implementable depth, flag concerns
 
 ---
 
@@ -75,15 +75,15 @@ Artifact: `_ai/docs/tech-adr.md` (incrementally appended per category) (aka road
 | 3 | Synthesize findings and approaches | `references/research-phase.md` → Synthesis Format |
 | 4 | User selects approach and create ADR-000 | `references/research-phase.md` + `references/artifact-structure.md` |
 | 5 | Work through categories 1-15 in order | `references/categories.md` + `references/workflow.md` → Category Loop + `references/rules.md` + `references/formats.md` |
-| 6 | Append approved category decisions | `references/formats.md` → CATEGORY APPEND + `references/artifact-structure.md` |
-| 7 | Run final verification (3 parallel agents) | `references/workflow.md` → Final Verification |
+| 6 | Auto-append full category sections | `references/formats.md` → CATEGORY APPEND + `references/artifact-structure.md` |
+| 7 | Completeness gate, then final verification (3 agents) | `references/workflow.md` |
 | 8 | Display completion message | `references/workflow.md` → Completion |
 
 **Key rules throughout** (full text in `references/rules.md` + `references/formats.md`):
-- Ask one question per response with 3-5 numbered options.
-- Run verification triage for factual decisions.
-- Display status block in every response.
-- Use adaptive retrieval per `references/web-search.md` when claims are factual/impactful.
+- Status block every response; hybrid Ask (full QUESTION FORMAT markdown **then** Question tool).
+- Batch residual gap questions per category (default); gaps-only — do not re-ask product-adr locks.
+- Auto-append at 90%+; completeness gate before PHASE 2 COMPLETE.
+- Run verification triage / adaptive retrieval when claims are factual/impactful.
 
 ---
 
@@ -92,4 +92,4 @@ Artifact: `_ai/docs/tech-adr.md` (incrementally appended per category) (aka road
 1. Load and follow `references/workflow.md` and `references/rules.md`.
 2. Validate input; if missing, emit the ERROR block above and stop.
 3. Execute steps 1–8 in order, loading the reference files in the table above at the stated times.
-4. Do not skip the research phase, 90% clarity gate, preview-before-append, or final verification.
+4. Do not skip research, 90% clarity, completeness gate, or final verification.

--- a/.opencode/skills/technical-requirements/references/artifact-structure.md
+++ b/.opencode/skills/technical-requirements/references/artifact-structure.md
@@ -4,6 +4,21 @@ Verbatim tech-adr.md artifact skeleton from technical-requirements Phase 2.
 
 ---
 
+## Minimum bar (before PHASE 2 COMPLETE)
+
+Applicable sections must be implementable (not summary-only):
+- Types/tables/contracts where the category needs them
+- ≥1 lifecycle or how-it-works flow when behavior is non-trivial
+- Decisions with Why; package/versions when deps are chosen
+- NOT APPLICABLE categories: short explicit N/A + why (do not omit chapter)
+- Unknowns that need a device/lib POC: mark as POC gates, not facts
+
+**Junior heuristic:** implementable from `tech-adr.md` + `product-adr.md` alone.  
+**Offline/no-backend:** §5 APIs may be internal module contracts (not empty).  
+If thin → expand pass, then final verification.
+
+---
+
 ## ARTIFACT STRUCTURE: tech-adr.md
 
 ```markdown
@@ -11,7 +26,7 @@ Verbatim tech-adr.md artifact skeleton from technical-requirements Phase 2.
 
 Generated: [YYYY-MM-DD]
 Status: [In Progress | Complete]
-Source: product-adr.md.md
+Source: product-adr.md
 
 ---
 

--- a/.opencode/skills/technical-requirements/references/formats.md
+++ b/.opencode/skills/technical-requirements/references/formats.md
@@ -25,6 +25,15 @@ Display this status block in EVERY response:
 
 **Calculation:** `[X]% remaining = 100 - ((completed categories / 15) × 100)` — represents how much of the entire 15-category workflow remains to be done.
 
+## HYBRID ASK (MANDATORY)
+
+Before every Question tool call, in the same response:
+1. TRACKING FORMAT status block
+2. Full QUESTION FORMAT markdown for all residual gaps this turn (batch per category by default)
+3. Then Question tool (`question` = one short sentence; `label` = 1–5 words + optional `(Recommended)`; `description` = one line `MUST: … | PRO: … | CON: …`)
+
+Never Question-tool-only.
+
 ## QUESTION FORMAT (MANDATORY)
 
 ```
@@ -39,21 +48,9 @@ Display this status block in EVERY response:
    - Complexity: [Low/Medium/High] | [Time estimate]
    - Over-engineered? [No / Yes: explanation/suggestion]
 
-2. **[UX TITLE: What users experience if this is chosen]** 
-   - Why: [1 sentence explaining why this is better for current constraints]
-   - How: [1 sentence detail implementation approach/mechanism (for engineering record)]
-   - Tradeoff: [Primary downside or risk]
-   - Complexity: [Low/Medium/High] | [Time estimate]
-   - Over-engineered? [No / Yes: explanation/suggestion]
+2–N. **[Same structure as option 1]** — repeat for each remaining choice (typically 3–5 total options)
 
-3. **[UX TITLE: What users experience if this is chosen]** 
-   - Why: [1 sentence explaining why this is better for current constraints]
-   - How: [1 sentence detail implementation approach/mechanism (for engineering record)]
-   - Tradeoff: [Primary downside or risk]
-   - Complexity: [Low/Medium/High] | [Time estimate]
-   - Over-engineered? [No / Yes: explanation/suggestion]
-
-4. **[Search for best practices]**
+N. **[Search for best practices]** (optional last option)
    - I'll research current best practices and library options for this
 
 RECOMMENDATION: [1-2 sentences - favor idiomatic/pragmatic options; tie to solo dev, validation phase constraints]
@@ -108,52 +105,20 @@ ASSESSMENT: [APPLICABLE | PARTIALLY APPLICABLE | NOT APPLICABLE]
 
 ## CATEGORY APPEND FORMAT
 
-When a category reaches 90% clarity, present this preview.
-For this category-finalization preview only, include `Simple Decision` and `How It Works (Plain)` sections.
-
-**CRITICAL:** Preview is for session display. When writing to `tech-adr.md`, use the format defined for that category in `ARTIFACT STRUCTURE`.
+When a category reaches 90%+ clarity:
+1. Write the **full** section per `ARTIFACT STRUCTURE` (Minimum bar — not summary-only)
+2. **Auto-append** to `_ai/docs/tech-adr.md` (do not wait for yes/no)
+3. Optionally show a short notice (non-blocking):
 
 ```
 ═══════════════════════════════════════════════════════════════════════
-CATEGORY COMPLETE: [Category Name]
+CATEGORY COMPLETE: [Category Name] — APPENDED
 CLARITY: [X]%
 ═══════════════════════════════════════════════════════════════════════
 
-PREVIEW - I will append the following to `_ai/docs/tech-adr.md`:
-
----
-
-## [Category Name]
-
-[Formatted content based on clarified items]
-
-### Simple Decision
-
-[4-6 plain-language bullets explaining decision summary]
-
-### How It Works (Plain)
-
-[2-4 plain-language bullets explaining how the decision works]
-
-### Category Decisions
-
-#### [Topic]: [Choice Made]
-- **Why:** [1-2 sentence rationale tying back to constraints]
-
-#### [Topic]: [Choice Made]
-- **Why:** [1-2 sentence rationale]
-
-### Code Evidence
-[Optional - include if subagent was spawned]
-
-```typescript
-// Source: [Framework] v[X.Y]
-// URL: [docs URL]
-[code snippet]
-
----
-
-Does this look correct? Reply "yes" to append, or provide corrections.
+Appended §[N] to `_ai/docs/tech-adr.md`. Next: Category [N+1]
 ```
+
+Session may still include Simple Decision / How It Works / Category Decisions / Code Evidence in chat for transparency; **file write must be full artifact-structure depth.**
 
 ---

--- a/.opencode/skills/technical-requirements/references/research-phase.md
+++ b/.opencode/skills/technical-requirements/references/research-phase.md
@@ -8,6 +8,10 @@ Verbatim pre-category research phase from technical-requirements Phase 2.
 
 Before diving into the 15 categories, spawn 6 parallel research subagents to explore technical approaches. This ensures decisions are grounded in real-world implementations, not assumptions.
 
+### Codebase-first (when repo exists)
+
+If `package.json` / app code is present: summarize the locked stack; default **Approach 1 = keep current stack** unless product-adr forces a pivot. Focus research on deltas (libs, POCs, permissions), not greenfield rewrites.
+
 ### Subagent Missions
 
 | Agent             | Mission                                                       |
@@ -123,11 +127,5 @@ Concerns:
 
 Which approach would you like to proceed with? (Enter 1-5 or describe your own)
 ```
-
-### After User Selects Approach
-
-1. Create ADR-000 documenting the decision (see ADR template below)
-2. Proceed to Category 1: Key Components
-3. All subsequent category decisions should align with the selected approach
 
 ---

--- a/.opencode/skills/technical-requirements/references/rules.md
+++ b/.opencode/skills/technical-requirements/references/rules.md
@@ -7,14 +7,17 @@ Verbatim critical rules, principles, and frameworks from technical-requirements 
 ## CRITICAL RULES
 
 ### Questioning Rules
-1. **One question at a time** - Ask exactly ONE question per response
-2. **Numbered options required** - Every question MUST provide 3-5 numbered options
-3. **Plain-language scenario framing** - Frame each question as a concrete scenario in everyday words a non-developer could understand. Avoid technical jargon in the question itself (e.g. "type contracts", "schema migration", "reactive subscriptions"). Describe the *decision being made* in terms of what happens, not how it's implemented.
+1. **Batch gaps per category (default)** - Ask all residual gap questions for the current category in one turn (one-at-a-time only if user asks or one decision must block the rest)
+2. **Hybrid Ask (mandatory)** - Same turn, in order: (a) TRACKING status block (b) full QUESTION FORMAT markdown in chat (c) Question tool. Never call Question tool without (a)+(b). Tool labels: short plain text; `description` one line with `|` separators.
+3. **Numbered options required** - Every question MUST provide 3-5 numbered options
+4. **Gaps-only** - Do not re-ask items already locked in product-adr, ADR-000, or prior tech-adr categories; auto-include those in the section write-up; Ask only residual gaps
+5. **Plain-language scenario framing** - Frame each question as a concrete scenario in everyday words a non-developer could understand. Avoid technical jargon in the question itself (e.g. "type contracts", "schema migration", "folder split", "registry"). Describe the *decision being made* in terms of what happens, not how it's implemented.
    - Plain language test: "Could someone who doesn't code understand what's being decided from the question alone?"
    - Before/after example — BAD: "How should types flow between the Convex schema and the React client?" | GOOD: "When the database defines what a result looks like, does your UI code use that definition directly — or define its own copy?"
-4. **Complete option format** - Each option MUST include: Why pick this, User impact, Tradeoff, Complexity with time estimate, Technical details
+6. **Complete option format** - Each option MUST include: Why pick this, User impact, Tradeoff, Complexity with time estimate, Technical details (How)
    - Option titles must be acceptance-criteria-style statements in simple natural language that are scannable at a glance.
-5. **Grounded suggestions only (adaptive)** - Memory is a starting point, not final evidence.
+   - Mark one **Recommended** when ETHOS/product/repo evidence supports it
+7. **Grounded suggestions only (adaptive)** - Memory is a starting point, not final evidence.
    - Use retrieval when claims are factual and impactful (pricing, API behavior, security, limits, version-specific behavior)
    - Skip retrieval when the decision is preference-only and does not depend on external facts
    - Be liberal with focused verification subagents when factual uncertainty exists; prefer quick verification over unverified memory
@@ -22,9 +25,9 @@ Verbatim critical rules, principles, and frameworks from technical-requirements 
    - If uncertain, state explicitly: "I need to research this"
    - Source priority: Official docs > Maintainer docs/repo > Recent issues/changelog > Third-party blogs
    - Then present grounded options with citations (URL + accessed date + version/date context)
-6. **Reference product requirements** - Tie technical decisions back to product needs
-7. **Favor idiomatic & pragmatic** - Weight recommendations toward options that are idiomatic to the stack and pragmatic for solo dev context
-8. **Avoid layered solutions by default** - In solo dev validation phase, do not propose multi-layered solutions when one simple approach meets the need (see Progression Rule 3).
+8. **Reference product requirements** - Tie technical decisions back to product needs
+9. **Favor idiomatic & pragmatic** - Weight recommendations toward options that are idiomatic to the stack and pragmatic for solo dev context
+10. **Avoid layered solutions by default** - In solo dev validation phase, do not propose multi-layered solutions when one simple approach meets the need (see Progression Rule 3).
 
 ### Progression Rules
 1. **90% clarity threshold** - Cannot move to next category until current is at 90%+
@@ -34,16 +37,19 @@ Verbatim critical rules, principles, and frameworks from technical-requirements 
    - State reasoning briefly to the user (do NOT ask the user)
    - Proceed with applicable portions, skip what doesn't apply
    - User can override if AI's assessment is wrong
+   - NOT APPLICABLE: still append a short N/A section (why) — do not omit the chapter
 3. **No over-engineering** - Recommend simplest solution that meets requirements
 4. **Thin end-to-end first** - Prioritize decisions for the tracer bullet implementation
+5. **Auto-append** - At 90%+ clarity, append immediately; do not wait for "does this preview look correct?"
 
 ### Artifact Rules
-1. **Preview before writing** - Before appending to `tech-adr.md`, show a preview and ask: "Does this look correct before I append?"
+1. **Full detail on write** - Append meets artifact-structure depth (types/contracts/flows as relevant), not summary-only bullets. Junior heuristic: implementable from tech-adr + product-adr alone.
 2. **Create directory if needed** - If `_ai/docs/` doesn't exist, create it
 3. **Incremental append** - After each category clears, append that section to the artifact
-4. **Never overwrite** - Always append, never replace existing content
+4. **Never overwrite** - Always append, never replace existing content (except explicit expand-pass fixes)
 5. **Capture decision rationale** - For each significant decision in a category, record the options considered and why the choice was made
-6. **Full detail** - Include schemas, contracts, versions - detailed enough for a jr dev to start building
+6. **Completeness gate** - Before PHASE 2 COMPLETE: every applicable section meets Minimum bar in artifact-structure.md; expand thin sections first; then final verification
+7. **Feedback file** - At session start, create/update `technical-requirements-workflow-feedback.md`; append friction when user corrects the workflow
 
 ---
 
@@ -82,21 +88,9 @@ Display this status block in EVERY response:
    - Complexity: [Low/Medium/High] | [Time estimate]
    - Over-engineered? [No / Yes: explanation/suggestion]
 
-2. **[UX TITLE: What users experience if this is chosen]** 
-   - Why: [1 sentence explaining why this is better for current constraints]
-   - How: [1 sentence detail implementation approach/mechanism (for engineering record)]
-   - Tradeoff: [Primary downside or risk]
-   - Complexity: [Low/Medium/High] | [Time estimate]
-   - Over-engineered? [No / Yes: explanation/suggestion]
+2–N. **[Same structure as option 1]** — repeat for each remaining choice (typically 3–5 total options)
 
-3. **[UX TITLE: What users experience if this is chosen]** 
-   - Why: [1 sentence explaining why this is better for current constraints]
-   - How: [1 sentence detail implementation approach/mechanism (for engineering record)]
-   - Tradeoff: [Primary downside or risk]
-   - Complexity: [Low/Medium/High] | [Time estimate]
-   - Over-engineered? [No / Yes: explanation/suggestion]
-
-4. **[Search for best practices]**
+N. **[Search for best practices]** (optional last option)
    - I'll research current best practices and library options for this
 
 RECOMMENDATION: [1-2 sentences - favor idiomatic/pragmatic options; tie to solo dev, validation phase constraints]
@@ -104,6 +98,7 @@ RECOMMENDATION: [1-2 sentences - favor idiomatic/pragmatic options; tie to solo 
 SOURCES (only when factual verification is used):
 - [Source URL, accessed YYYY-MM-DD, version/date]
 ```
+(Canonical copy: `references/formats.md`.)
 
 ### Question Format Field Reference
 
@@ -151,53 +146,7 @@ ASSESSMENT: [APPLICABLE | PARTIALLY APPLICABLE | NOT APPLICABLE]
 
 ## CATEGORY APPEND FORMAT
 
-When a category reaches 90% clarity, present this preview.
-For this category-finalization preview only, include `Simple Decision` and `How It Works (Plain)` sections.
-
-**CRITICAL:** Preview is for session display. When writing to `tech-adr.md`, use the format defined for that category in `ARTIFACT STRUCTURE`.
-
-```
-═══════════════════════════════════════════════════════════════════════
-CATEGORY COMPLETE: [Category Name]
-CLARITY: [X]%
-═══════════════════════════════════════════════════════════════════════
-
-PREVIEW - I will append the following to `_ai/docs/tech-adr.md`:
-
----
-
-## [Category Name]
-
-[Formatted content based on clarified items]
-
-### Simple Decision
-
-[4-6 plain-language bullets explaining decision summary]
-
-### How It Works (Plain)
-
-[2-4 plain-language bullets explaining how the decision works]
-
-### Category Decisions
-
-#### [Topic]: [Choice Made]
-- **Why:** [1-2 sentence rationale tying back to constraints]
-
-#### [Topic]: [Choice Made]
-- **Why:** [1-2 sentence rationale]
-
-### Code Evidence
-[Optional - include if subagent was spawned]
-
-```typescript
-// Source: [Framework] v[X.Y]
-// URL: [docs URL]
-[code snippet]
-
----
-
-Does this look correct? Reply "yes" to append, or provide corrections.
-```
+Canonical append UX lives in `references/formats.md` (auto-append at 90%+; full section per `artifact-structure.md`). Do not use a blocking “reply yes to append” preview.
 
 ---
 

--- a/.opencode/skills/technical-requirements/references/workflow.md
+++ b/.opencode/skills/technical-requirements/references/workflow.md
@@ -14,14 +14,15 @@ Verbatim workflow sections from technical-requirements Phase 2.
 | 3    | Synthesize findings and approaches             | RESEARCH PHASE -> Synthesis Format            | After all agents return           |
 | 4    | User selects approach and create ADR-000       | RESEARCH PHASE -> After User Selects Approach | Before Category 1                 |
 | 5    | Work through categories 1-15 in order          | CATEGORIES + WORKFLOW -> Category Loop        | Sequentially                      |
-| 6    | Append approved category decisions to artifact | CATEGORY APPEND FORMAT                        | After 90% clarity + user approval |
-| 7    | Run final verification (3 parallel agents)     | WORKFLOW -> Final Verification                | After all categories complete     |
+| 6    | Auto-append full category sections to artifact | CATEGORY APPEND FORMAT                        | After 90% clarity (no yes/no wait)|
+| 7    | Completeness gate, then final verification     | WORKFLOW -> Completeness Gate + Final Verification | After all categories        |
 | 8    | Display completion message                     | WORKFLOW -> Completion                        | After verification passes         |
 
 **Key rules throughout:**
-- Ask one question per response with 3-5 numbered options (CRITICAL RULES).
+- Status block every response; hybrid Ask (QUESTION FORMAT markdown then Question tool); batch gaps per category (CRITICAL RULES).
+- Gaps-only: skip product-adr / already-locked items.
 - Run verification triage for factual decisions (WORKFLOW -> Category Loop).
-- Display status block in every response (TRACKING FORMAT).
+- Completeness gate before PHASE 2 COMPLETE.
 
 ---
 
@@ -37,16 +38,20 @@ Verbatim workflow sections from technical-requirements Phase 2.
 1. Verify product requirements file was provided
 2. Read and summarize the product requirements
 3. Create `_ai/docs/` directory if it doesn't exist
-4. **RESEARCH PHASE:** Spawn 6 parallel subagents (Product Teardown, Open Source Scan, Framework Compare, Cost Projection, Architecture Patterns, SaaS Boilerplate)
-5. **SYNTHESIS:** Present raw findings summary + 5 distinct approaches + recommendation
-6. **APPROACH SELECTION:** User selects approach → Create ADR-000 (with selected + rejected approaches)
-7. Start with Category 1 (Boundaries)
-8. Ask applicability check: "Let's start with Boundaries. Based on the product requirements, let me identify what's technically out of scope."
+4. Create/update `technical-requirements-workflow-feedback.md` (append friction live if user corrects workflow)
+5. If repo stack exists (`package.json` / app): note it for codebase-first research (see research-phase)
+6. **RESEARCH PHASE:** Spawn 6 parallel subagents (Product Teardown, Open Source Scan, Framework Compare, Cost Projection, Architecture Patterns, SaaS Boilerplate) — codebase-first when stack locked
+7. **SYNTHESIS:** Present raw findings summary + 5 distinct approaches + recommendation
+8. **APPROACH SELECTION:** User selects approach → Create ADR-000 (with selected + rejected approaches)
+9. Start with Category 1 (Boundaries)
+10. Ask applicability check: "Let's start with Boundaries. Based on the product requirements, let me identify what's technically out of scope."
 
 ### Category Loop
 1. Display applicability check (self-assessed) for the category
-2. If applicable: ask one question at a time with numbered options
-3. After each user answer, run Verification Triage:
+2. Gaps-only: list already-locked items (product-adr / prior tech-adr); do not re-ask them
+3. If NOT APPLICABLE: append short N/A section (why); continue
+4. If applicable with residual gaps: **batch** all gap questions — status block + full QUESTION FORMAT markdown + Question tool (hybrid). If no gaps: append full section from locks/defaults
+5. After user answers, run Verification Triage:
    - Decision type: Preference | Factual | High-risk factual
    - Confidence: High (>=85%) | Medium (50-84%) | Low (<50%)
    - Action:
@@ -54,13 +59,11 @@ Verbatim workflow sections from technical-requirements Phase 2.
      - Factual + Medium confidence -> quick check (1 official source)
      - High-risk factual or Low confidence -> deep check (2+ sources, spawn 1-3 focused subagents when useful)
      - Default for factual/high-risk factual decisions: favor focused subagent verification unless recent, high-confidence evidence is already available
-4. Track clarity after each answer (use verified facts when retrieval is triggered)
-5. When category reaches 90%:
+6. Track clarity after answers (use verified facts when retrieval is triggered)
+7. When category reaches 90%:
    - Spawn subagent for current docs research when code examples would help
-   - Show preview (include code evidence if subagent was spawned)
-   - Wait for user approval
-   - Append to `tech-adr.md`
-   - Move to next category
+   - Auto-append **full** section to `tech-adr.md` (artifact-structure depth; no yes/no wait)
+   - Brief "Appended §N" notice; move to next category
 
 ### Retroactive Updates
 
@@ -83,9 +86,17 @@ Which approach?
 ───────────────────────────────────────────────────────────────────────
 ```
 
+### Completeness Gate (before Final Verification)
+
+Before PHASE 2 COMPLETE / final verification:
+1. Each applicable category section meets Minimum bar in `artifact-structure.md` (types/contracts/flows as relevant — not summary-only)
+2. Each NOT APPLICABLE category has an explicit N/A section
+3. Junior heuristic: implementable from `tech-adr.md` + `product-adr.md` alone
+4. If thin: **expand pass** on weak sections, then continue
+
 ### Final Verification
 
-Before completion, spawn 3 parallel verification subagents to validate `tech-adr.md`.
+Before completion, spawn 3 parallel verification subagents to validate the **full** `tech-adr.md` (post–completeness gate).
 
 | Agent           | Mission                                             | Pass Criteria                           |
 | --------------- | --------------------------------------------------- | --------------------------------------- |


### PR DESCRIPTION
## Summary
Ports technical-requirements skill hardening from qodi session friction (P0–P2):

- **Hybrid Ask**: status + full QUESTION markdown, then Question tool (never tool-only)
- **Batch gaps** per category; **gaps-only** (skip product-adr locks)
- **Auto-append** at 90%+ (no yes/no preview gate)
- **Completeness gate** before PHASE 2 COMPLETE (minimum bar / junior heuristic)
- **Codebase-first** research when a repo stack exists
- Condensed QUESTION option template (option 1 full; 2–N same structure)

## Test plan
- [ ] Open `.opencode/skills/technical-requirements/SKILL.md` and confirm key rules match hybrid/batch/auto-append/completeness
- [ ] Grep skill for `Reply \"yes\" to append` — should be absent
- [ ] Dry-run `/technical-requirements` mental walkthrough: category loop uses batch + auto-append
- [ ] Confirm command `02-technical-requirements.md` still loads this skill (unchanged if already modular)

## Source
Backported from `iamhenry/qodi-qr-code-app` commits `cb59c3f` / `0144cee`.