### PR TITLE
chore(opencode): use Swarm CLI for cell workflows

### DIFF
--- a/.opencode/command/workflow/01-plan/04-file-cells.md
+++ b/.opencode/command/workflow/01-plan/04-file-cells.md
@@ -65,7 +65,7 @@ Analyze task relationships to determine execution waves and explicit DAG edges:
 - Implementation (components, functions, adapters) → Wave 2 (Priority 2)
 - Integration (routes, wiring, orchestration) → Wave 3 (Priority 1)
 
-**Use `hive_cells` to check existing cells and avoid duplicates.**
+**Use `swarm tool hive_cells` to check existing cells and avoid duplicates.**
 
 ---
 
@@ -135,12 +135,12 @@ DAG_DEPENDS_ON_IDS: {comma-separated cell IDs or PENDING_RESOLUTION}
 
 ### PHASE 4: Create Cells
 
-1. `hive_create_epic(epic_title, epic_description, subtasks)` - Create structure
+1. `swarm tool hive_create_epic` - Create structure
 2. Resolve predecessor task keys to created cell IDs
 3. Persist structured dependency edges on each task (`dependencies` array) using available hive/swarm tooling
-4. Read back updated cells and verify `dependencies` match planned predecessors
-5. `hive_update(id, description)` - Add detailed descriptions with line refs + DAG lines
-6. `hive_sync()` - Sync to git
+4. Read back cells with `swarm tool hive_cells` and verify `dependencies` match planned predecessors
+5. `swarm tool hive_update` - Add detailed descriptions with line refs + DAG lines
+6. `swarm tool hive_sync` - Sync to git
 
 ---
 
@@ -159,7 +159,7 @@ Re-read document and verify:
 - [ ] Every milestone has exactly one terminal `Verify + Commit milestone work` cell
 - [ ] Terminal gate cell depends on all other cells in its milestone
 
-Update cells with corrections via `hive_update` if needed.
+Update cells with corrections via `swarm tool hive_update` if needed.
 
 If structured `dependencies` cannot be persisted/read back, mark result as BLOCKED and report tooling gap (do not claim DAG-complete).
 

--- a/.opencode/command/workflow/01-plan/05-verify-cells-ensemble.md
+++ b/.opencode/command/workflow/01-plan/05-verify-cells-ensemble.md
@@ -13,6 +13,8 @@ Spawns parallel verification tasks across multiple AI models using tmux, then sy
 
 - Roadmap.md
 
+Use the public Swarm CLI for Hive access: `swarm tool hive_cells`.
+
 ## Interactive Flow
 
 Present all questions with defaults. User presses Enter to accept defaults.
@@ -30,7 +32,7 @@ Present all questions with defaults. User presses Enter to accept defaults.
 ---
 Summary:
 - Roadmap: _ai/docs/ROADMAP.md
-- Cells: hive_cells()
+- Cells: `swarm tool hive_cells`
 - Models: opus, gemini, gpt (3 verifications)
 - Focus: none
 
@@ -88,7 +90,7 @@ Verify that the cells created from the ROADMAP.md plan are:
 ## Instructions
 
 1. First, read the roadmap: `cat _ai/docs/ROADMAP.md`
-2. Get the cells list using the `hive_cells()` MCP tool
+2. Get the cells list using `swarm tool hive_cells --json '{"limit":200}'`
 3. Compare each milestone/phase against created cells
 
 ## Verification Checklist
@@ -204,7 +206,7 @@ Present results from all models with consensus analysis.
 ## Scope
 
 **Roadmap:** _ai/docs/ROADMAP.md
-**Cells:** hive_cells() (45 cells)
+**Cells:** `swarm tool hive_cells` (45 cells)
 **Focus:** {additional_context or "General verification"}
 **Models:** {count} ({model_list})
 
@@ -263,4 +265,4 @@ _Where models disagreed:_
 
 - `tmux` - for parallel session management
 - `opencode run` - for running models with `--model` and `--format json` flags
-- `hive_cells()` - MCP tool for listing cells (available to spawned models)
+- `swarm` CLI - public Hive cell listing


### PR DESCRIPTION
## Summary
- route file-cells Hive operations through the public Swarm CLI
- use the same CLI path when the verification ensemble lists cells
- preserve existing workflow structure, DAG policy, and verification behavior

## Validation
- 
- upstream comparison contains only the two workflow Markdown files